### PR TITLE
Unable to mint from fresh wallet with payment tokenPayment guard

### DIFF
--- a/src/hooks/useCandyMachineV3.tsx
+++ b/src/hooks/useCandyMachineV3.tsx
@@ -62,7 +62,7 @@ export default function useCandyMachineV3(
   const [nftHoldings, setNftHoldings] = React.useState<Metadata[]>([]);
 
   const tokenHoldings = React.useMemo<Token[]>(() => {
-    if (!nftHoldings?.length || !allTokens?.length) return [];
+    if (!nftHoldings || !allTokens?.length) return [];
     return allTokens.filter(
       (x) => !nftHoldings.find((y) => x.mint.equals(y.address))
     );


### PR DESCRIPTION
When the wallet connected has no NFTs at all (from any sort), the UI is always complaining that there is "insufficient token balance", even though there is more than enough to mint and to satisfy the condition of the CM guard.

Problem seems to be coming just from one if, my version seems to work. 